### PR TITLE
Digitalocean DNS provider

### DIFF
--- a/terraform/modules/dns/digitalocean/main.tf
+++ b/terraform/modules/dns/digitalocean/main.tf
@@ -22,7 +22,7 @@ resource "digitalocean_record" "floating_ip" {
 
   domain   = digitalocean_domain.default.name
   type     = "A"
-  name     = var.cluster_domain
+  name     = "@"
   value    = var.floating_ip
   ttl      = 600
 }
@@ -32,7 +32,7 @@ resource "digitalocean_record" "cluster_cname" {
 
   domain   = digitalocean_domain.default.name
   type     = "CNAME"
-  name     = var.cluster_domain
-  value    = var.cluster_domain
+  name     = "*."
+  value    = "@"
   ttl      = 600
 }

--- a/terraform/modules/dns/digitalocean/main.tf
+++ b/terraform/modules/dns/digitalocean/main.tf
@@ -1,0 +1,38 @@
+provider "digitalocean" {
+  version = "~> 1.11"
+  token = var.digitalocean_token
+}
+
+resource "digitalocean_domain" "default" {
+  name = var.cluster_domain
+}
+
+resource "digitalocean_record" "nodes" {
+  for_each = var.servers
+
+  domain   = digitalocean_domain.default.name
+  type     = "A"
+  name     = each.value.name
+  value    = var.server_ips[each.key]
+  ttl      = 600
+}
+
+resource "digitalocean_record" "floating_ip" {
+  count = var.cluster_enable_floating_ip ? 1 : 0 # Only if floating ip is enabled
+
+  domain   = digitalocean_domain.default.name
+  type     = "A"
+  name     = var.cluster_domain
+  value    = var.floating_ip
+  ttl      = 600
+}
+
+resource "digitalocean_record" "cluster_cname" {
+  count = var.cluster_enable_floating_ip ? 1 : 0 # Only if floating ip is enabled
+
+  domain   = digitalocean_domain.default.name
+  type     = "CNAME"
+  name     = var.cluster_domain
+  value    = var.cluster_domain
+  ttl      = 600
+}

--- a/terraform/modules/dns/digitalocean/variables.tf
+++ b/terraform/modules/dns/digitalocean/variables.tf
@@ -1,0 +1,11 @@
+# Cluster configuration
+
+variable "cluster_domain" {}
+variable "cluster_enable_floating_ip" {}
+variable "servers" {}
+variable "server_ips" {}
+variable "floating_ip" {}
+
+# Provider configuration - Digital Ocean
+
+variable "digitalocean_token" {}


### PR DESCRIPTION
There currently isn't really a nice way to "switch" between providers, you have to comment out some the CloudFlare variables and comment in the DigitalOcean ones, so I haven't changed anything except add the provider.