### PR TITLE
Fix Interpolation-only expressions are deprecated warning

### DIFF
--- a/terraform/clusters/core/main.tf
+++ b/terraform/clusters/core/main.tf
@@ -12,42 +12,42 @@ terraform {
 module "provider" {
   source = "../../modules/provider/hcloud"
 
-  hcloud_token          = "${var.hcloud_token}"
-  hcloud_manage_ssh_key = "${var.hcloud_manage_ssh_key}"
+  hcloud_token          = var.hcloud_token
+  hcloud_manage_ssh_key = var.hcloud_manage_ssh_key
   
-  cluster_name                = "${var.cluster_name}"
-  cluster_domain              = "${var.cluster_domain}"
-  cluster_enable_floating_ip  = "${var.cluster_enable_floating_ip}"
-  servers                      = "${var.servers}"
+  cluster_name                = var.cluster_name
+  cluster_domain              = var.cluster_domain
+  cluster_enable_floating_ip  = var.cluster_enable_floating_ip
+  servers                      = var.servers
 
-  ssh_public_key        = "${var.ssh_public_key}"
-  ssh_public_key_name   = "${var.ssh_public_key_name}"
+  ssh_public_key        = var.ssh_public_key
+  ssh_public_key_name   = var.ssh_public_key_name
 }
 
 # Provision DNS
 module "dns" {
   source = "../../modules/dns/cloudflare"
 
-  cloudflare_email    = "${var.cloudflare_email}"
-  cloudflare_api_key  = "${var.cloudflare_api_key}"
-  cloudflare_zone_id  = "${var.cloudflare_zone_id}"
+  cloudflare_email    = var.cloudflare_email
+  cloudflare_api_key  = var.cloudflare_api_key
+  cloudflare_zone_id  = var.cloudflare_zone_id
   
-  cluster_domain              = "${var.cluster_domain}"
-  cluster_enable_floating_ip  = "${var.cluster_enable_floating_ip}"
-  servers                     = "${var.servers}"
+  cluster_domain              = var.cluster_domain
+  cluster_enable_floating_ip  = var.cluster_enable_floating_ip
+  servers                     = var.servers
 
-  server_ips      = "${module.provider.server_ips}"
-  floating_ip     = "${module.provider.floating_ip}"
+  server_ips      = module.provider.server_ips
+  floating_ip     = module.provider.floating_ip
 }
 
 # Ansible Inventory
 module "ansible_inventory" {
   source = "../../modules/ansible/ansible-inventory"
 
-  cluster_name    = "${var.cluster_name}"
-  cluster_domain  = "${var.cluster_domain}"
-  servers         = "${var.servers}"
-  server_ips      = "${module.provider.server_ips}"
-  floating_ip     = "${module.provider.floating_ip}"
-  private_network = "${module.provider.private_network}"
+  cluster_name    = var.cluster_name
+  cluster_domain  = var.cluster_domain
+  servers         = var.servers
+  server_ips      = module.provider.server_ips
+  floating_ip     = module.provider.floating_ip
+  private_network = module.provider.private_network
 }

--- a/terraform/clusters/default/main.tf
+++ b/terraform/clusters/default/main.tf
@@ -12,55 +12,55 @@ terraform {
 module "provider" {
   source = "../../modules/provider/hcloud"
 
-  hcloud_token          = "${var.hcloud_token}"
-  hcloud_manage_ssh_key = "${var.hcloud_manage_ssh_key}"
+  hcloud_token          = var.hcloud_token
+  hcloud_manage_ssh_key = var.hcloud_manage_ssh_key
   
-  cluster_name                = "${var.cluster_name}"
-  cluster_domain              = "${var.cluster_domain}"
-  cluster_enable_floating_ip  = "${var.cluster_enable_floating_ip}"
-  servers                      = "${var.servers}"
+  cluster_name                = var.cluster_name
+  cluster_domain              = var.cluster_domain
+  cluster_enable_floating_ip  = var.cluster_enable_floating_ip
+  servers                      = var.servers
 
-  ssh_public_key        = "${var.ssh_public_key}"
-  ssh_public_key_name   = "${var.ssh_public_key_name}"
+  ssh_public_key        = var.ssh_public_key
+  ssh_public_key_name   = var.ssh_public_key_name
 
-  rancher_agent_node_command = "${module.k8s.rancher_agent_node_command}"
+  rancher_agent_node_command = module.k8s.rancher_agent_node_command
 }
 
 # Provision DNS
 module "dns" {
   source = "../../modules/dns/cloudflare"
 
-  cloudflare_email    = "${var.cloudflare_email}"
-  cloudflare_api_key  = "${var.cloudflare_api_key}"
-  cloudflare_zone_id  = "${var.cloudflare_zone_id}"
+  cloudflare_email    = var.cloudflare_email
+  cloudflare_api_key  = var.cloudflare_api_key
+  cloudflare_zone_id  = var.cloudflare_zone_id
   
-  cluster_domain              = "${var.cluster_domain}"
-  cluster_enable_floating_ip  = "${var.cluster_enable_floating_ip}"
-  servers                     = "${var.servers}"
+  cluster_domain              = var.cluster_domain
+  cluster_enable_floating_ip  = var.cluster_enable_floating_ip
+  servers                     = var.servers
 
-  server_ips      = "${module.provider.server_ips}"
-  floating_ip     = "${module.provider.floating_ip}"
+  server_ips      = module.provider.server_ips
+  floating_ip     = module.provider.floating_ip
 }
 
 # Ansible Inventory
 module "ansible_inventory" {
   source = "../../modules/ansible/ansible-inventory"
 
-  cluster_name    = "${var.cluster_name}"
-  cluster_domain  = "${var.cluster_domain}"
-  servers         = "${var.servers}"
-  server_ips      = "${module.provider.server_ips}"
-  floating_ip     = "${module.provider.floating_ip}"
-  private_network = "${module.provider.private_network}"
+  cluster_name    = var.cluster_name
+  cluster_domain  = var.cluster_domain
+  servers         = var.servers
+  server_ips      = module.provider.server_ips
+  floating_ip     = module.provider.floating_ip
+  private_network = module.provider.private_network
 }
 
 # Provision Rancher2 Agents
 module "k8s" {
   source = "../../modules/k8s/rancher2-agent"
   
-  rancher_api_url             = "${var.rancher_api_url}"
-  rancher_bearer_token        = "${var.rancher_bearer_token}"
-  rancher_kubernetes_version  = "${var.rancher_kubernetes_version}"
+  rancher_api_url             = var.rancher_api_url
+  rancher_bearer_token        = var.rancher_bearer_token
+  rancher_kubernetes_version  = var.rancher_kubernetes_version
 
-  cluster_name    = "${var.cluster_name}"
+  cluster_name    = var.cluster_name
 }

--- a/terraform/modules/ansible/ansible-inventory/main.tf
+++ b/terraform/modules/ansible/ansible-inventory/main.tf
@@ -4,7 +4,7 @@ provider "local" {
 
 locals {
   rancher_domain_names = [for key, value in var.servers: "${value.name}.${var.cluster_domain}" if value.install_rancher]
-  rancher_ips = [for key, value in var.servers: "${var.server_ips[key]}" if value.install_rancher]
+  rancher_ips = [for key, value in var.servers: var.server_ips[key] if value.install_rancher]
 }
 
 # Create Ansible Inventory file

--- a/terraform/modules/dns/cloudflare/main.tf
+++ b/terraform/modules/dns/cloudflare/main.tf
@@ -1,37 +1,37 @@
 provider "cloudflare" {
   version = "~> 2.0"
-  email   = "${var.cloudflare_email}"
-  api_key = "${var.cloudflare_api_key}"
+  email   = var.cloudflare_email
+  api_key = var.cloudflare_api_key
 }
 
 resource "cloudflare_record" "nodes" {
-  for_each = "${var.servers}"
+  for_each = var.servers
 
-  zone_id = "${var.cloudflare_zone_id}"
+  zone_id = var.cloudflare_zone_id
   name    = "${each.value.name}.${var.cluster_domain}"
-  value   = "${var.server_ips[each.key]}"
+  value   = var.server_ips[each.key]
   type    = "A"
   proxied = false
   ttl     = 600
 }
 
 resource "cloudflare_record" "floating_ip" {
-  count = "${var.cluster_enable_floating_ip ? 1 : 0}" # Only if floating ip is enabled
+  count = var.cluster_enable_floating_ip ? 1 : 0 # Only if floating ip is enabled
 
-  zone_id = "${var.cloudflare_zone_id}"
-  name    = "${var.cluster_domain}"
-  value   = "${var.floating_ip}"
+  zone_id = var.cloudflare_zone_id
+  name    = var.cluster_domain
+  value   = var.floating_ip
   type    = "A"
   proxied = false
   ttl     = 600
 }
 
 resource "cloudflare_record" "cluster_cname" {
-  count = "${var.cluster_enable_floating_ip ? 1 : 0}" # Only if floating ip is enabled
+  count = var.cluster_enable_floating_ip ? 1 : 0 # Only if floating ip is enabled
 
-  zone_id = "${var.cloudflare_zone_id}"
+  zone_id = var.cloudflare_zone_id
   name    = "*.${var.cluster_domain}"
-  value   = "${var.cluster_domain}"
+  value   = var.cluster_domain
   type    = "CNAME"
   proxied = false
   ttl     = 600

--- a/terraform/modules/k8s/rancher2-agent/main.tf
+++ b/terraform/modules/k8s/rancher2-agent/main.tf
@@ -1,13 +1,13 @@
 provider "rancher2" {
   version = "~> 1.6"
   
-  api_url     = "${var.rancher_api_url}"
-  token_key   = "${var.rancher_bearer_token}"
+  api_url     = var.rancher_api_url
+  token_key   = var.rancher_bearer_token
 }
 
 # Configure cluster
 resource "rancher2_cluster" "default" {
-  name = "${var.cluster_name}"
+  name = var.cluster_name
 
   cluster_auth_endpoint {
     enabled = true
@@ -24,7 +24,7 @@ resource "rancher2_cluster" "default" {
       }
     }
     
-    kubernetes_version = "${var.rancher_kubernetes_version}"
+    kubernetes_version = var.rancher_kubernetes_version
 
     ingress {
       provider = "none"

--- a/terraform/modules/k8s/rancher2-agent/output.tf
+++ b/terraform/modules/k8s/rancher2-agent/output.tf
@@ -1,3 +1,3 @@
 output "rancher_agent_node_command" {
-  value = "${rancher2_cluster.default.cluster_registration_token.0.node_command}"
+  value = rancher2_cluster.default.cluster_registration_token[0].node_command
 }

--- a/terraform/modules/provider/hcloud/main.tf
+++ b/terraform/modules/provider/hcloud/main.tf
@@ -1,20 +1,20 @@
 provider "hcloud" {
   version = "~> 1.14"
-  token = "${var.hcloud_token}"
+  token = var.hcloud_token
 }
 
 # SSH
 resource "hcloud_ssh_key" "default" {
-  count = "${var.hcloud_manage_ssh_key ? 1 : 0}" # Only if SSH key is managed by Terraform
+  count = var.hcloud_manage_ssh_key ? 1 : 0 # Only if SSH key is managed by Terraform
 
-  name       = "${var.ssh_public_key_name}"
-  public_key = "${file(var.ssh_public_key)}"
+  name       = var.ssh_public_key_name
+  public_key = file(var.ssh_public_key)
 }
 
 data "hcloud_ssh_key" "default" {
-  count = "${var.hcloud_manage_ssh_key ? 0 : 1}" # Only if SSH key is not managed by Terraform
+  count = var.hcloud_manage_ssh_key ? 0 : 1 # Only if SSH key is not managed by Terraform
 
-  name       = "${var.ssh_public_key_name}"
+  name       = var.ssh_public_key_name
 }
 
 # Servers
@@ -25,17 +25,17 @@ resource "hcloud_server" "node" {
   //server_type = "${each.value.server_type}"
 
   // Provision using count instead
-  count       = "${length(values(var.servers))}"
+  count       = length(values(var.servers))
   name        = "${var.cluster_name}-${lookup(element(values(var.servers), count.index), "name")}"
-  server_type = "${lookup(element(values(var.servers), count.index), "server_type")}"
+  server_type = lookup(element(values(var.servers), count.index), "server_type")
 
-  image       = "${var.hcloud_image}"
-  location    = "${var.hcloud_location}"
-  backups     = "${var.hcloud_backups}"
-  ssh_keys    = ["${length(hcloud_ssh_key.default) > 0 ? hcloud_ssh_key.default.0.name : length(data.hcloud_ssh_key.default) > 0 ? data.hcloud_ssh_key.default.0.name : ""}"]
+  image       = var.hcloud_image
+  location    = var.hcloud_location
+  backups     = var.hcloud_backups
+  ssh_keys    = [length(hcloud_ssh_key.default) > 0 ? hcloud_ssh_key.default.0.name : length(data.hcloud_ssh_key.default) > 0 ? data.hcloud_ssh_key.default.0.name : ""]
 
   labels = {
-    cluster = "${var.cluster_name}"
+    cluster = var.cluster_name
     domain = "${lookup(element(values(var.servers), count.index), "name")}.${var.cluster_domain}"
   }
 
@@ -46,7 +46,7 @@ resource "hcloud_server" "node" {
     ]
 
     connection {
-      host        = "${self.ipv4_address}"
+      host        = self.ipv4_address
     }
   }
 
@@ -57,17 +57,17 @@ resource "hcloud_server" "node" {
 
   # Install Rancher if server is configured so
   provisioner "local-exec" {
-    command = "${lookup(element(values(var.servers), count.index), "install_rancher") == true ? "cd ${path.root}/../../../ansible/ && ANSIBLE_CONFIG=ansible.cfg ansible-playbook -i '${self.ipv4_address},' --extra-vars 'rancher_ip_address=${self.ipv4_address} rancher_domain_name=${lookup(element(values(var.servers), count.index), "name")}.${var.cluster_domain}' provision-rancher2.yml" : "sleep 0"}"
+    command = lookup(element(values(var.servers), count.index), "install_rancher") == true ? "cd ${path.root}/../../../ansible/ && ANSIBLE_CONFIG=ansible.cfg ansible-playbook -i '${self.ipv4_address},' --extra-vars 'rancher_ip_address=${self.ipv4_address} rancher_domain_name=${lookup(element(values(var.servers), count.index), "name")}.${var.cluster_domain}' provision-rancher2.yml" : "sleep 0"
   }
 
   # Install Rancher Agent if server is configured so
   provisioner "remote-exec" {
     inline = [
-      "${lookup(element(values(var.servers), count.index), "install_rancher_agent") == true ? "${var.rancher_agent_node_command} --internal-address ${lookup(element(values(var.servers), count.index), "private_ip_address")} --address ${self.ipv4_address} ${lookup(element(values(var.servers), count.index), "rancher_agent_roles")}" : "sleep 0"}",
+      lookup(element(values(var.servers), count.index), "install_rancher_agent") == true ? "${var.rancher_agent_node_command} --internal-address ${lookup(element(values(var.servers), count.index), "private_ip_address")} --address ${self.ipv4_address} ${lookup(element(values(var.servers), count.index), "rancher_agent_roles")}" : "sleep 0",
     ]
 
     connection {
-      host        = "${self.ipv4_address}"
+      host        = self.ipv4_address
       user        = "deploy"
     }
   }
@@ -75,59 +75,59 @@ resource "hcloud_server" "node" {
 
 # Floating IP
 resource "hcloud_floating_ip" "default" {
-  count = "${var.cluster_enable_floating_ip ? 1 : 0}" # Only if floating ip is enabled
+  count = var.cluster_enable_floating_ip ? 1 : 0 # Only if floating ip is enabled
 
   type          = "ipv4"
-  description   = "${var.cluster_name}"
-  home_location = "${var.hcloud_location}"
+  description   = var.cluster_name
+  home_location = var.hcloud_location
 
   labels = {
-    cluster = "${var.cluster_name}"
-    domain = "${var.cluster_domain}"
+    cluster = var.cluster_name
+    domain = var.cluster_domain
   }
 }
 resource "hcloud_floating_ip_assignment" "default" {
-  count = "${var.cluster_enable_floating_ip ? 1 : 0}" # Only if floating ip is enabled
+  count = var.cluster_enable_floating_ip ? 1 : 0 # Only if floating ip is enabled
 
-  floating_ip_id = "${hcloud_floating_ip.default.0.id}"
-  server_id = "${hcloud_server.node.0.id}" # Default to first node
+  floating_ip_id = hcloud_floating_ip.default[0].id
+  server_id = hcloud_server.node[0].id # Default to first node
 }
 
 # Reverse DNS
 resource "hcloud_rdns" "node" {
-  for_each = "${var.servers}"
+  for_each = var.servers
 
-  server_id       = "${lookup(hcloud_server.node[each.key], "id")}"
-  ip_address      = "${lookup(hcloud_server.node[each.key], "ipv4_address")}"
+  server_id       = lookup(hcloud_server.node[each.key], "id")
+  ip_address      = lookup(hcloud_server.node[each.key], "ipv4_address")
   dns_ptr         = "${each.value.name}.${var.cluster_domain}"
 }
 resource "hcloud_rdns" "floating_ip_default" {
-  count = "${var.cluster_enable_floating_ip ? 1 : 0}" # Only if floating ip is enabled
+  count = var.cluster_enable_floating_ip ? 1 : 0 # Only if floating ip is enabled
 
-  floating_ip_id  = "${hcloud_floating_ip.default.0.id}"
-  ip_address      = "${hcloud_floating_ip.default.0.ip_address}"
-  dns_ptr         = "${var.cluster_domain}"
+  floating_ip_id  = hcloud_floating_ip.default[0].id
+  ip_address      = hcloud_floating_ip.default[0].ip_address
+  dns_ptr         = var.cluster_domain
 }
 
 # Private network
 resource "hcloud_network" "default" {
-  name      = "${var.cluster_name}"
-  ip_range  = "${var.hcloud_network_ip_range}"
+  name      = var.cluster_name
+  ip_range  = var.hcloud_network_ip_range
 
   labels = {
-    cluster = "${var.cluster_name}"
+    cluster = var.cluster_name
   }
 }
 resource "hcloud_network_subnet" "default" {
-  network_id    = "${hcloud_network.default.id}"
+  network_id    = hcloud_network.default.id
   type          = "server"
-  network_zone  = "${var.hcloud_network_zone}"
-  ip_range      = "${var.hcloud_network_subnet_ip_range}"
+  network_zone  = var.hcloud_network_zone
+  ip_range      = var.hcloud_network_subnet_ip_range
 }
 resource "hcloud_server_network" "node" {
-  for_each = "${var.servers}"
+  for_each = var.servers
 
-  network_id  = "${hcloud_network.default.id}"
-  server_id   = "${lookup(hcloud_server.node[each.key], "id")}"
-  ip          = "${each.value.private_ip_address}"
+  network_id  = hcloud_network.default.id
+  server_id   = lookup(hcloud_server.node[each.key], "id")
+  ip          = each.value.private_ip_address
 }

--- a/terraform/modules/provider/hcloud/output.tf
+++ b/terraform/modules/provider/hcloud/output.tf
@@ -1,9 +1,9 @@
 output "server_ips" {
-  value = {for key, value in var.servers : key => "${lookup(hcloud_server.node[key], "ipv4_address")}"}
+  value = {for key, value in var.servers : key => lookup(hcloud_server.node[key], "ipv4_address")}
 }
 output "floating_ip" {
-  value = "${var.cluster_enable_floating_ip && length(hcloud_floating_ip.default) > 0 ? hcloud_floating_ip.default.0.ip_address : ""}"
+  value = var.cluster_enable_floating_ip && length(hcloud_floating_ip.default) > 0 ? hcloud_floating_ip.default.0.ip_address : ""
 }
 output "private_network" {
-  value = "${hcloud_network.default.name}"
+  value = hcloud_network.default.name
 }


### PR DESCRIPTION
In newer versions of Terraform, interpolation-only expressions are deprecated and trigger a warning.